### PR TITLE
typo fix in exports.social

### DIFF
--- a/ga/ga.js
+++ b/ga/ga.js
@@ -22,7 +22,7 @@ exports.event = function event(category, action, label, value) {
   return init().send(MapBuilder.createEvent(category, action, label, value).build());
 };
 
-exports.scocial = function social(network, action, target) {
+exports.social = function social(network, action, target) {
 
   if (typeof network === 'object') {
     var args = network;


### PR DESCRIPTION
there was a typo in exports.scocial, I've removed the unneeded "c" char
